### PR TITLE
Hotfix hack the box scanning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -250,3 +250,6 @@ paket-files/
 # JetBrains Rider
 .idea/
 *.sln.iml
+*.pyc
+*.pyproj
+*.sln

--- a/reconnoitre/service_scan.py
+++ b/reconnoitre/service_scan.py
@@ -14,7 +14,7 @@ def nmap_scan(ip_address, output_directory, dns_server, quick):
    ip_address = ip_address.strip()
    
    print("[+] Starting quick nmap scan for %s" % (ip_address))
-   QUICKSCAN = "nmap -Pn -n -oN '%s/%s.quick.nmap' %s"  % (output_directory, ip_address, ip_address)
+   QUICKSCAN = "nmap -sC sV %s -oA '%s/%s.quick'"  % (ip_address, output_directory, ip_address)
    quickresults = subprocess.check_output(QUICKSCAN, shell=True)
    
    write_recommendations(quickresults, ip_address, output_directory)
@@ -31,7 +31,7 @@ def nmap_scan(ip_address, output_directory, dns_server, quick):
    else:
        print("[+] Starting detailed TCP/UDP nmap scans for %s" % (ip_address))
        TCPSCAN = "nmap -vv -Pn -sS -A -sC -p- -T 3 -script-args=unsafe=1 -n %s -oN '%s/%s.nmap' -oX '%s/%s_nmap_scan_import.xml' %s"  % (dns_server, output_directory, ip_address, output_directory, ip_address, ip_address)
-       UDPSCAN = "unicornscan -mU %s -l %s/%s_unicornscan.txt" % (ip_address, output_directory, ip_address)
+       UDPSCAN = "nmap -sC -sV -sU %s -l %s/%s-udp" % (ip_address, output_directory, ip_address)
 
    udpresults = subprocess.check_output(UDPSCAN, shell=True)
    tcpresults = subprocess.check_output(TCPSCAN, shell=True)

--- a/reconnoitre/service_scan.py
+++ b/reconnoitre/service_scan.py
@@ -14,7 +14,7 @@ def nmap_scan(ip_address, output_directory, dns_server, quick):
    ip_address = ip_address.strip()
    
    print("[+] Starting quick nmap scan for %s" % (ip_address))
-   QUICKSCAN = "nmap -sC sV %s -oA '%s/%s.quick'"  % (ip_address, output_directory, ip_address)
+   QUICKSCAN = "nmap -sC -sV %s -oA '%s/%s.quick'"  % (ip_address, output_directory, ip_address)
    quickresults = subprocess.check_output(QUICKSCAN, shell=True)
    
    write_recommendations(quickresults, ip_address, output_directory)


### PR DESCRIPTION
Resolves issue #8 

Appears that the VPN concentrator for HTB also has some limiting. Recommend to use single target, with quick scan. 

Output of successful test case below for reference:

> 
> root@kali:~/Source/Reconnoitre# python ./reconnoitre/reconnoitre.py -t 10.10.10.5 -o /root/Documents/scans/hackthebox/ --services --quick
>   __
> |"""\-=  RECONNOITRE
> (____)      An OSCP scanner
> 
> [#] Performing service scans
> [*] Loaded single target: 10.10.10.5
> [+] Creating directory structure for 10.10.10.5
>    [>] Creating scans directory at: /root/Documents/scans/hackthebox/10.10.10.5/scans
>    [>] Creating exploit directory at: /root/Documents/scans/hackthebox/10.10.10.5/exploit
>    [>] Creating loot directory at: /root/Documents/scans/hackthebox/10.10.10.5/loot
>    [>] Creating proof file at: /root/Documents/scans/hackthebox/10.10.10.5/proof.txt
> [+] Starting quick nmap scan for 10.10.10.5
> [+] Writing findings for 10.10.10.5
>    [>] Found FTP service on 10.10.10.5:21
>    [>] Found HTTP service on 10.10.10.5:80
> [*] TCP quick scans completed for 10.10.10.5
> 