### PR TITLE
bugfix and re-work in snmp_walk.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ This tool can be used and copied for personal use freely however attribution and
 | --dnssweep | Find DNS servers from the list of target(s). |
 | --snmp | Find hosts responding to SNMP requests from the list of target(s). |
 | --services | Perform a service scan over the target(s) and write recommendations for further commands to execute. |
-| --snmpwalk | SNMP walk target hosts and save results. |
 | --hostnames | Attempt to discover target hostnames and write to hostnames.txt. |
 | --virtualhosts | Attempt to discover virtual hosts using the specified wordlist. This can be expended via discovered hostnames. |
 | --ignore-http-codes | Comma separated list of http codes to ignore with virtual host scans. |

--- a/reconnoitre/snmp_walk.py
+++ b/reconnoitre/snmp_walk.py
@@ -4,7 +4,7 @@ import socket
 import os
 import time
 from multiprocessing import Process, Queue
-from file_helper import check_directory
+from file_helper import check_directory, load_targets
 
 
 def valid_ip(address):
@@ -57,20 +57,15 @@ def snmp_walk(target_hosts, output_directory, quiet):
         target_ip(target_hosts, output_directory, quiet)
     else:
         target_file(target_hosts, output_directory, quiet)
-
+        
 def snmp_scans(ip_address, output_directory):
     print("[+] Performing SNMP scans for %s to %s" % (ip_address, output_directory))
-
     print("   [>] Performing snmpwalk on public tree for: %s - Checking for System Processes" % (ip_address))
     SCAN = "snmpwalk -c public -v1 %s 1.3.6.1.2.1.25.1.6.0 > '%s%s-systemprocesses.txt'"  % (ip_address, output_directory, ip_address)
-    results = subprocess.check_output(SCAN, shell=True)
-    check_results(results, ip_address)
+
+    try:
+        results = subprocess.check_output(SCAN, stderr=subprocess.STDOUT, shell=True).decode('utf-8')
+    except Exception as e:
+        print("[+] No Response from %s" % ip_address)
 
     print("[+] Completed SNMP scans for %s" % (ip_address))
-
-def check_results(results, ip_address):
-    lines = results.split("\n")
-    for line in lines:
-       line = line.strip()
-       if ("No Response" in line):
-            print("No response from %s" % ip_address)

--- a/reconnoitre/snmp_walk.py
+++ b/reconnoitre/snmp_walk.py
@@ -67,5 +67,7 @@ def snmp_scans(ip_address, output_directory):
         results = subprocess.check_output(SCAN, stderr=subprocess.STDOUT, shell=True).decode('utf-8')
     except Exception as e:
         print("[+] No Response from %s" % ip_address)
+    except subprocess.CalledProcessError as cpe:
+        print("[+] Subprocess failure during scan of %s" % ip_address)
 
     print("[+] Completed SNMP scans for %s" % (ip_address))


### PR DESCRIPTION
(1) Bugfix, (1) Re-work to clean up output in 2.7 and 3

Bugfix:
[1] - Added omitted 'load_targets' function import on line 7 that resulted in traceback / crash when module ran.

Rework:
[1] - snmp_scans() has been changed to clean up the output when this def runs.  Prior to the re-work, the output on error was quite ugly, chock full of traceback, printed errors, and more.  With this rework, the tracebacks are caught and output is uniform in all cases (success and non-success).  

This re-work also in-lined the decode('utf-8') of 'results' on line 67 such that if additional functionality is added later, the results can be used as a string as needed, rather than the byte-encoded value returned by check_output normally, which often results in a TypeError being thrown.

As an added bonus, the re-work eliminated the need for the redundant check_results() function, since the test it was performing is now done internally to the snmp_scans().

Tested in both python 2.7 and python 3