### PR TITLE
Update file_helper to split host ranges provided as arguments

### DIFF
--- a/reconnoitre/file_helper.py
+++ b/reconnoitre/file_helper.py
@@ -13,8 +13,26 @@ def check_directory(output_directory):
 def load_targets(target_hosts, output_directory, quiet):
     if(os.path.isdir(target_hosts) or os.path.isfile(target_hosts)):
         return target_hosts
+    elif "-" in target_hosts:
+        expand_targets(target_hosts, output_directory)
+        return "targets.txt"
     else:
         return output_directory + "/targets.txt"
+
+def expand_targets(target_hosts, output_directory):
+    parts = target_hosts.split(".")
+    target_list= []
+    print(parts)
+    for part in parts:
+        if "-" in part:
+            iprange = part.split("-")
+            print(iprange)
+    for i in range(int(iprange[0]), int(iprange[1])):
+        target_list.append(parts[0]+"."+parts[1]+"."+parts[2]+"."+str(i))
+    print(target_list)
+    with open(output_directory + "/targets.txt", "w") as targets:
+        for target in target_list:
+            targets.write("%s\n" % target)
 
 
 def create_dir_structure(ip_address, output_directory):

--- a/reconnoitre/file_helper.py
+++ b/reconnoitre/file_helper.py
@@ -22,14 +22,11 @@ def load_targets(target_hosts, output_directory, quiet):
 def expand_targets(target_hosts, output_directory):
     parts = target_hosts.split(".")
     target_list= []
-    print(parts)
     for part in parts:
         if "-" in part:
             iprange = part.split("-")
-            print(iprange)
     for i in range(int(iprange[0]), int(iprange[1])):
         target_list.append(parts[0]+"."+parts[1]+"."+parts[2]+"."+str(i))
-    print(target_list)
     with open(output_directory + "/targets.txt", "w") as targets:
         for target in target_list:
             targets.write("%s\n" % target)

--- a/reconnoitre/file_helper.py
+++ b/reconnoitre/file_helper.py
@@ -15,7 +15,7 @@ def load_targets(target_hosts, output_directory, quiet):
         return target_hosts
     elif "-" in target_hosts:
         expand_targets(target_hosts, output_directory)
-        return "targets.txt"
+        return output_directory + "/targets.txt"
     else:
         return output_directory + "/targets.txt"
 


### PR DESCRIPTION
PR to update how IP range handling is completed by Reconnoitre based on a bug raised here:
https://github.com/codingo/Reconnoitre/issues/37

This fix splits all IPs in the range specified in the arguments passed to the script and outputs the list in the output directory's targets.txt file.