### PR TITLE
Update to snmp_walk.py

### DIFF
--- a/Reconnoitre/lib/snmp_walk.py
+++ b/Reconnoitre/lib/snmp_walk.py
@@ -60,8 +60,8 @@ def snmp_walk(target_hosts, output_directory, quiet):
 def snmp_scans(ip_address, output_directory):
     print("[+] Performing SNMP scans for %s to %s" % (ip_address, output_directory))
     print("   [>] Performing snmpwalk on public tree for: %s - Checking for System Processes" % (ip_address))
-    SCAN = "snmpwalk -c public -v1 %s 1.3.6.1.2.1.25.1.6.0 > '%s%s-systemprocesses.txt'" % (
-        ip_address, output_directory, ip_address)
+    SCAN = ("snmpwalk -c public -v1 %s 1.3.6.1.2.1.25.1.6.0 > '%s%s-systemprocesses.txt'" % (
+        ip_address, output_directory, ip_address))
 
     try:
         subprocess.check_output(SCAN, stderr=subprocess.STDOUT, shell=True).decode("utf-8").decode('utf-8')


### PR DESCRIPTION
Updated code to fix "TypeError: not all arguments converted during string formatting python" because of multiline variable missing paranthesis.