### PR TITLE
Update subprocess calls for python3, fix TypeError

### DIFF
--- a/Reconnoitre/lib/find_dns.py
+++ b/Reconnoitre/lib/find_dns.py
@@ -27,7 +27,7 @@ def find_dns(target_hosts, output_directory, quiet):
 
         print("   [>] Testing %s for DNS" % ip_address)
         DNSSCAN = "nmap -n -sV -Pn -vv -p53 %s" % (ip_address)
-        results = subprocess.check_output(DNSSCAN, shell=True).decode("utf-8")
+        results = subprocess.check_output(DNSSCAN, shell=True, text=True)
         lines = results.split("\n")
 
         for line in lines:

--- a/Reconnoitre/lib/hostname_scan.py
+++ b/Reconnoitre/lib/hostname_scan.py
@@ -18,7 +18,7 @@ def hostname_scan(target_hosts, output_directory, quiet):
     else:
         SWEEP = "nbtscan -q %s" % (target_hosts)
 
-    results = subprocess.check_output(SWEEP, shell=True).decode("utf-8")
+    results = subprocess.check_output(SWEEP, shell=True,text=True)
     lines = results.split("\n")
 
     for line in lines:

--- a/Reconnoitre/lib/ping_sweeper.py
+++ b/Reconnoitre/lib/ping_sweeper.py
@@ -23,8 +23,7 @@ def ping_sweeper(target_hosts, output_directory, quiet):
 def call_nmap_sweep(target_hosts):
     SWEEP = "nmap -n -sP %s" % (target_hosts)
 
-    results = subprocess.check_output(SWEEP, shell=True)
-    lines = str(results).encode("utf-8").split("\n")
+    results = subprocess.check_output(SWEEP, shell=True, text=True)
     return lines
 
 

--- a/Reconnoitre/lib/service_scan.py
+++ b/Reconnoitre/lib/service_scan.py
@@ -20,7 +20,7 @@ def nmap_scan(
     QUICKSCAN = "nmap -sC -sV -Pn --disable-arp-ping %s -oA '%s/%s.quick'" % (
         ip_address, output_directory, ip_address)
     quickresults = subprocess.check_output(
-        QUICKSCAN, shell=True).decode("utf-8")
+        QUICKSCAN, shell=True,text=True)
 
     write_recommendations(quickresults, ip_address, output_directory)
     print("[*] TCP quick scans completed for %s" % ip_address)
@@ -70,8 +70,8 @@ def nmap_scan(
             ip_address, output_directory, ip_address)
 
     udpresult = "" if no_udp_service_scan is True else subprocess.check_output(
-        UDPSCAN, shell=True).decode("utf-8")
-    tcpresults = subprocess.check_output(TCPSCAN, shell=True).decode("utf-8")
+        UDPSCAN, shell=True, text=True)
+    tcpresults = subprocess.check_output(TCPSCAN, shell=True, text=True)
 
     write_recommendations(tcpresults + udpresult, ip_address, output_directory)
     print("[*] TCP%s scans completed for %s" %

--- a/Reconnoitre/lib/snmp_walk.py
+++ b/Reconnoitre/lib/snmp_walk.py
@@ -76,7 +76,8 @@ def snmp_scans(ip_address, output_directory):
         subprocess.check_output(
             SCAN,
             stderr=subprocess.STDOUT,
-            shell=True).decode("utf-8").decode('utf-8')
+            shell=True,
+            text=True)
     except Exception:
         print("[+] No Response from %s" % ip_address)
     except subprocess.CalledProcessError:


### PR DESCRIPTION
Using Reconnoitre on PwK Kali, as well as current Manjaro Linux, Python 3 fails the subprocess calls with a TypeError, since it is expecting a byte array rather than a text string. 
Slight change returns decoded string in current locale without having to explicitly call decode().