### PR TITLE
Fix python 3.6 compat issue with subprocess.Popen keyword arguments && creating helper function 'run_scan' to create a subprocess, moving subprocess logic to helper. 

### DIFF
--- a/Reconnoitre/lib/find_dns.py
+++ b/Reconnoitre/lib/find_dns.py
@@ -1,7 +1,6 @@
-import subprocess
-
 from Reconnoitre.lib.file_helper import check_directory
 from Reconnoitre.lib.file_helper import load_targets
+from Reconnoitre.lib.subprocess_helper import run_scan
 
 
 def find_dns(target_hosts, output_directory, quiet):
@@ -27,7 +26,7 @@ def find_dns(target_hosts, output_directory, quiet):
 
         print("   [>] Testing %s for DNS" % ip_address)
         DNSSCAN = "nmap -n -sV -Pn -vv -p53 %s" % (ip_address)
-        results = subprocess.check_output(DNSSCAN, shell=True, text=True)
+        results = run_scan(DNSSCAN)
         lines = results.split("\n")
 
         for line in lines:

--- a/Reconnoitre/lib/hostname_scan.py
+++ b/Reconnoitre/lib/hostname_scan.py
@@ -1,7 +1,7 @@
 import os
-import subprocess
 
 from Reconnoitre.lib.file_helper import check_directory
+from Reconnoitre.lib.subprocess_helper import run_scan
 
 
 def hostname_scan(target_hosts, output_directory, quiet):
@@ -18,7 +18,7 @@ def hostname_scan(target_hosts, output_directory, quiet):
     else:
         SWEEP = "nbtscan -q %s" % (target_hosts)
 
-    results = subprocess.check_output(SWEEP, shell=True,text=True)
+    results = run_scan(SWEEP)
     lines = results.split("\n")
 
     for line in lines:

--- a/Reconnoitre/lib/ping_sweeper.py
+++ b/Reconnoitre/lib/ping_sweeper.py
@@ -1,6 +1,5 @@
-import subprocess
-
 from Reconnoitre.lib.file_helper import check_directory
+from Reconnoitre.lib.subprocess_helper import run_scan
 
 
 def ping_sweeper(target_hosts, output_directory, quiet):
@@ -23,7 +22,8 @@ def ping_sweeper(target_hosts, output_directory, quiet):
 def call_nmap_sweep(target_hosts):
     SWEEP = "nmap -n -sP %s" % (target_hosts)
 
-    results = subprocess.check_output(SWEEP, shell=True, text=True)
+    results = run_scan(SWEEP)
+    lines = str(results).encode("utf-8").split("\n")
     return lines
 
 

--- a/Reconnoitre/lib/service_scan.py
+++ b/Reconnoitre/lib/service_scan.py
@@ -1,11 +1,11 @@
 import multiprocessing
 import socket
-import subprocess
 
 from Reconnoitre.lib.file_helper import check_directory
 from Reconnoitre.lib.file_helper import create_dir_structure
 from Reconnoitre.lib.file_helper import load_targets
 from Reconnoitre.lib.file_helper import write_recommendations
+from Reconnoitre.lib.subprocess_helper import run_scan
 
 
 def nmap_scan(
@@ -19,8 +19,7 @@ def nmap_scan(
     print("[+] Starting quick nmap scan for %s" % (ip_address))
     QUICKSCAN = "nmap -sC -sV -Pn --disable-arp-ping %s -oA '%s/%s.quick'" % (
         ip_address, output_directory, ip_address)
-    quickresults = subprocess.check_output(
-        QUICKSCAN, shell=True,text=True)
+    quickresults = run_scan(QUICKSCAN)
 
     write_recommendations(quickresults, ip_address, output_directory)
     print("[*] TCP quick scans completed for %s" % ip_address)
@@ -69,9 +68,8 @@ def nmap_scan(
         UDPSCAN = "nmap -sC -sV -sU -Pn --disable-arp-ping %s -oA '%s/%s-udp'" % (
             ip_address, output_directory, ip_address)
 
-    udpresult = "" if no_udp_service_scan is True else subprocess.check_output(
-        UDPSCAN, shell=True, text=True)
-    tcpresults = subprocess.check_output(TCPSCAN, shell=True, text=True)
+    udpresult = "" if no_udp_service_scan is True else run_scan(UDPSCAN)
+    tcpresults = run_scan(TCPSCAN)
 
     write_recommendations(tcpresults + udpresult, ip_address, output_directory)
     print("[*] TCP%s scans completed for %s" %

--- a/Reconnoitre/lib/snmp_walk.py
+++ b/Reconnoitre/lib/snmp_walk.py
@@ -3,6 +3,7 @@ import socket
 import subprocess
 
 from Reconnoitre.lib.file_helper import check_directory, load_targets
+from Reconnoitre.lib.subprocess_helper import run_scan
 
 
 def valid_ip(address):
@@ -73,11 +74,7 @@ def snmp_scans(ip_address, output_directory):
         ip_address, output_directory, ip_address))
 
     try:
-        subprocess.check_output(
-            SCAN,
-            stderr=subprocess.STDOUT,
-            shell=True,
-            text=True)
+        run_scan(SCAN, stderr=subprocess.STDOUT)
     except Exception:
         print("[+] No Response from %s" % ip_address)
     except subprocess.CalledProcessError:

--- a/Reconnoitre/lib/subprocess_helper.py
+++ b/Reconnoitre/lib/subprocess_helper.py
@@ -1,0 +1,8 @@
+import subprocess
+
+
+def run_scan(scan, stderr=None):
+    """Helper method to perform a scan using a subprocess and return results.
+    We use the same configuration options for each call to check_output, this
+    can be bunched into one helper function to keep config constant."""
+    return subprocess.check_output(scan, shell=True, stderr=stderr, universal_newlines=True)


### PR DESCRIPTION
This allows us to change the configuration/arguments supplied to scans in one place, rather than for every single scan.

This PR also fixes the issue with the "text" keyword argument to subprocess.check_output by using the backwards-compatible `universal_newlines` keyword argument. 

@tlavoie Would you mind reviewing this as well? 