### PR TITLE
Using dir command with gobuster

### DIFF
--- a/Reconnoitre/lib/config.json
+++ b/Reconnoitre/lib/config.json
@@ -31,8 +31,8 @@
                "commands":[  
                   "dirb http://$ip:$port/ -o $outputdir/$ip_$port_dirb.txt",
                   "dirbuster -H -u http://$ip:$port/ -l /usr/share/wordlists/dirbuster/directory-list-lowercase-2.3-medium.txt -t 20 -s / -v -r $outputdir/$ip_$port_dirbuster_medium.txt",
-                  "gobuster -w /usr/share/seclists/Discovery/Web-Content/common.txt -u http://$ip:$port/ -s '200,204,301,302,307,403,500' -e | tee '$outputdir/$ip_$port_gobuster_common.txt'",
-                  "gobuster -w /usr/share/seclists/Discovery/Web-Content/CGIs.txt -u http://$ip:$port/ -s '200,204,301,307,403,500' -e | tee '$outputdir/$ip_$port_gobuster_cgis.txt'"
+                  "gobuster dir -w /usr/share/seclists/Discovery/Web-Content/common.txt -u http://$ip:$port/ -s '200,204,301,302,307,403,500' -e | tee '$outputdir/$ip_$port_gobuster_common.txt'",
+                  "gobuster dir -w /usr/share/seclists/Discovery/Web-Content/CGIs.txt -u http://$ip:$port/ -s '200,204,301,307,403,500' -e | tee '$outputdir/$ip_$port_gobuster_cgis.txt'"
                ]
             }
          ]


### PR DESCRIPTION
The latest version of gobuster won't work without specifying dir before performing directory brute-forcing. Added `dir` in it.

Before:
`gobuster -w dict.txt -u http://$ip:$port/ -s '200,204,301,302,307,403,500' -e`

After:
`gobuster dir -w dict.txt -u http://$ip:$port/ -s '200,204,301,307,403,500' -e`