### PR TITLE
Scantype

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,3 +150,38 @@ mkdir /path/to/dir
 
 docker run -v /path/to/dir:/outputdir --services -o outputdir -t 127.0.0.1
 ```
+
+# Custom Scans
+
+You can specify custom scans that are not for specific services in the ```lib/config.json```. 
+
+Example Default:
+```
+    "scans":{
+        "default": {
+            "description": "Default scan",
+            "commands" : [
+            ]
+        }
+    },
+```
+The above is the default scan type to be ran when executing ```reconnoitre --scantype -t 192.168.1.1 -o output```
+
+Example Custom:
+```
+    "scans":{
+        "default": {
+            "description": "Default scan",
+            "commands" : [
+            ]
+        },
+        "custom": {
+            "description": "New custom scan",
+            "commands" : [
+                 "custom command 1",
+                 "custom command 2"
+            ]
+        }
+    },
+```
+The above configuration will allow you to run the custom commands listed when executing ```reconnoitre --scantype custom -t 192.168.1.1 -o output```

--- a/Reconnoitre/lib/config.json
+++ b/Reconnoitre/lib/config.json
@@ -5,6 +5,13 @@
         "dnsudpscan": "-vv -Pn --disable-arp-ping -A -sC -sU -T 4 --top-ports 200 --max-retries 0",
         "udpscan": "-sC -sV -sU -Pn --disable-arp-ping"
     },
+    "scans":{
+        "default": {
+            "description": "Default scan",
+            "commands" : [
+            ]
+        }
+    },
     "services": {
         "http/s": {
             "description": "Found HTTP/S service on $ip:$port",
@@ -37,8 +44,8 @@
                     "commands": [
                         "dirb http://$ip:$port/ -o $outputdir/$ip_$port_dirb.txt",
                         "dirbuster -H -u http://$ip:$port/ -l /usr/share/wordlists/dirbuster/directory-list-lowercase-2.3-medium.txt -t 20 -s / -v -r $outputdir/$ip_$port_dirbuster_medium.txt",
-                        "gobuster -w /usr/share/seclists/Discovery/Web-Content/common.txt -u http://$ip:$port/ -s '200,204,301,302,307,403,500' -e | tee '$outputdir/$ip_$port_gobuster_common.txt'",
-                        "gobuster -w /usr/share/seclists/Discovery/Web-Content/CGIs.txt -u http://$ip:$port/ -s '200,204,301,307,403,500' -e | tee '$outputdir/$ip_$port_gobuster_cgis.txt'"
+                        "gobuster dir -w /usr/share/seclists/Discovery/Web-Content/common.txt -u http://$ip:$port/ -s '200,204,301,302,307,403,500' -e | tee '$outputdir/$ip_$port_gobuster_common.txt'",
+                        "gobuster dir -w /usr/share/seclists/Discovery/Web-Content/CGIs.txt -u http://$ip:$port/ -s '200,204,301,307,403,500' -e | tee '$outputdir/$ip_$port_gobuster_cgis.txt'"
                     ]
                 }
             ]

--- a/Reconnoitre/lib/core/input.py
+++ b/Reconnoitre/lib/core/input.py
@@ -134,4 +134,14 @@ class CliArgumentParser(object):
                             action="store_true",
                             help="Disable UDP services scan over targets.",
                             default=False)
+
+        parser.add_argument("--scantype",
+                            nargs="?",
+                            dest="scantype",
+                            const="default",
+                            help='Use custom scantype defined in the '
+                            'config.json \"scans\" json object. If '
+                            'provide without arguments the default '
+                            'will be used.')
+
         return parser

--- a/Reconnoitre/reconnoitre.py
+++ b/Reconnoitre/reconnoitre.py
@@ -8,7 +8,7 @@ from .lib.core.input import CliArgumentParser
 from .lib.find_dns import find_dns
 from .lib.hostname_scan import hostname_scan
 from .lib.ping_sweeper import ping_sweeper
-from .lib.service_scan import service_scan
+from .lib.service_scan import service_scan, user_scan
 from .lib.snmp_walk import snmp_walk
 from .lib.virtual_host_scanner import VirtualHostScanner
 
@@ -134,6 +134,12 @@ def main():
                 arguments.ignore_content_length,
                 arguments.wordlist)
             scanner.scan()
+
+    if arguments.scantype:
+        print(f"[#] Performing scan {arguments.scantype}")
+        user_scan(arguments.target_hosts,
+                arguments.output_directory,
+                arguments.scantype)
 
 
 # Declare signal handler to immediately exit on KeyboardInterrupt


### PR DESCRIPTION
Added custom scans. Please let me know what you think of the implementation. I wasn't sure where the best place to put the user_scan should go (or if it should be a named such). If you would like users to be able to reuse the ```--scantype```multiple times to build a list of scans to run let me know.

# Custom Scans

You can specify custom scans that are not for specific services in the ```lib/config.json```. 

Example Default:
```
    "scans":{
        "default": {
            "description": "Default scan",
            "commands" : [
            ]
        }
    },
```
The above is the default scan type to be ran when executing ```reconnoitre --scantype -t 192.168.1.1 -o output```

Example Custom:
```
    "scans":{
        "default": {
            "description": "Default scan",
            "commands" : [
            ]
        },
        "custom": {
            "description": "New custom scan",
            "commands" : [
                 "custom command 1",
                 "custom command 2"
            ]
        }
    },
```
The above configuration will allow you to run the custom commands listed when executing ```reconnoitre --scantype custom -t 192.168.1.1 -o output```
