### PR TITLE
Use relative imports for the lib module

### DIFF
--- a/Reconnoitre/reconnoitre.py
+++ b/Reconnoitre/reconnoitre.py
@@ -4,13 +4,13 @@ import os
 import signal
 import sys
 
-from lib.core.input import CliArgumentParser
-from lib.find_dns import find_dns
-from lib.hostname_scan import hostname_scan
-from lib.ping_sweeper import ping_sweeper
-from lib.service_scan import service_scan
-from lib.snmp_walk import snmp_walk
-from lib.virtual_host_scanner import VirtualHostScanner
+from .lib.core.input import CliArgumentParser
+from .lib.find_dns import find_dns
+from .lib.hostname_scan import hostname_scan
+from .lib.ping_sweeper import ping_sweeper
+from .lib.service_scan import service_scan
+from .lib.snmp_walk import snmp_walk
+from .lib.virtual_host_scanner import VirtualHostScanner
 
 
 def print_banner():


### PR DESCRIPTION
Previously executing reconnoitre.py from a different
directory yielded the following error:

```
from lib.core.input import CliArgumentParser
ModuleNotFoundError: No module named 'lib.core'
```

This is because it was trying to import from lib, which is
not a python library (or in the pwd).

As per PEP-328, this change switches the imports to relative
imports which means that it works from an installed
location, but also maintains the previous support of
allowing local running.

Fixes codingo/Reconnoitre#118

Signed-off-by: Dave Walker (Daviey) <email@daviey.com>