### PR TITLE
Fix: detailed TCP scan uses  dns_server even if none is set

### DIFF
--- a/Reconnoitre/lib/service_scan.py
+++ b/Reconnoitre/lib/service_scan.py
@@ -50,7 +50,7 @@ def nmap_scan(
         print("[+] Starting detailed TCP%s nmap scans for %s" % (
             ("" if no_udp_service_scan is True else "/UDP"), ip_address))
         flags = get_config_options("nmap", "tcpscan")
-        TCPSCAN = f"nmap {flags} --dns-servers {dns_server} -oN\
+        TCPSCAN = f"nmap {flags} -oN\
         '{output_directory}/{ip_address}.nmap' -oX\
         '{output_directory}/{ip_address}_nmap_scan_import.xml' {ip_address}"
 


### PR DESCRIPTION
Observed error was:
```
[...]
[+] Starting detailed TCP nmap scans for 192.168.0.1
Unable to split netmask from target expression: "/tmp/192.168.0.1/scans/192.168.0.1.nmap"
mass_dns: warning: Unable to determine any DNS servers. Reverse DNS is disabled. Try using --system-dns or specify valid servers with --dns-servers
```
easily fixed by removing `dns_server` usage if none is set:
https://github.com/codingo/Reconnoitre/commit/843f63ff28725dd9cc6ae624d5f5687c47c28972#diff-dfe25e279ec5caa6f656464ed75c05a4L53
